### PR TITLE
Dim The Lights: More accurate pageOffset method

### DIFF
--- a/dim-the-lights/plugin.coffee
+++ b/dim-the-lights/plugin.coffee
@@ -7,7 +7,7 @@
   # Get the absolute offset of an element.
   pageOffset = (elem) ->
     body = document.body
-    win = document.defaultView
+    win = document.defaultView or document.window
     docElem = document.documentElement
 
     # Check the status of the box model
@@ -23,7 +23,7 @@
     clientTop  = docElem.clientTop  or body.clientTop  or 0
     clientLeft = docElem.clientLeft or body.clientLeft or 0
 
-    if win.pageYOffset?
+    if win?.pageYOffset?
       scrollTop = win.pageYOffset
       scrollLeft = win.pageXOffset
     else

--- a/dim-the-lights/plugin.js
+++ b/dim-the-lights/plugin.js
@@ -5,7 +5,7 @@
   pageOffset = function(elem) {
     var body, box, clientLeft, clientTop, docElem, scrollLeft, scrollTop, win;
     body = document.body;
-    win = document.defaultView;
+    win = document.defaultView || document.window;
     docElem = document.documentElement;
     if (isBoxModel == null) {
       box = document.createElement('div');
@@ -17,7 +17,7 @@
     box = elem.getBoundingClientRect();
     clientTop = docElem.clientTop || body.clientTop || 0;
     clientLeft = docElem.clientLeft || body.clientLeft || 0;
-    if (win.pageYOffset != null) {
+    if ((win != null ? win.pageYOffset : void 0) != null) {
       scrollTop = win.pageYOffset;
       scrollLeft = win.pageXOffset;
     } else {


### PR DESCRIPTION
This is to fix an issue with the pageOffset method that was causing it to misreport if there was a margin on the <html> element.

The new code is modeled off of this (which I believe was originally taken from jQuery): http://stackoverflow.com/questions/8111094/cross-browser-javascript-function-to-find-actual-position-of-an-element-in-page

@MaxPower15 This is a bit outside my area of expertise. I tested locally in Chrome, Safari, Firefox. Anything look suspect to you?
