### PR TITLE
Dc/no resumable when autoplay

### DIFF
--- a/resumable/index.html
+++ b/resumable/index.html
@@ -209,6 +209,10 @@ Menu
                     or <a href="#" id="show_example">show me an example</a>.
                   </span>
                 </p>
+
+                <p>
+                  <strong>Note:</strong> The Resumable Lab is incompatible with autoplay. If your video is set to autoplay, it will <em>always</em> autoplay. The Resumable Lab will not function.
+                </p>
               </div>
           </div>
         </div>

--- a/resumable/plugin.js
+++ b/resumable/plugin.js
@@ -1,12 +1,12 @@
 Wistia.plugin("resumable", function(video, options) {
 
   var uuid = Wistia.seqId("wistia_resumable");
-    
+
   function resumableKey() {
     return [video.params.pageUrl || location.href, video.hashedId(), "resume_time"];
   }
 
-  function setTime(t) {  
+  function setTime(t) {
     return Wistia.localStorage(resumableKey(), t);
   }
 
@@ -146,47 +146,52 @@ Wistia.plugin("resumable", function(video, options) {
   }
 
   function showOverlay() {
-    removeOverlay();
-    if (resumeTime()) {
-      if (video.state() === "beforeplay") {
-        video.suppressPlay(true);
-        video.pause();
-      } else {
-        video.pause();
-      }
-      var resumeScreen = document.createElement("div");
-      resumeScreen.id = uuid;
-      resumeScreen.innerHTML = "" +
-      "<div id='" + uuid + "_content'>" +
-      "<div>It looks like you've watched<br />part of this video before!</div>" +
-      "<a href='#' id='" + uuid + "_resume_play'>" +
-      "  <span id='" + uuid + "_resume_play_arrow'>&nbsp;</span>" +
-      "  Watch from the beginning" +
-      "</a><a href='#' id='" + uuid + "_resume_skip'>" +
-      "  <span id='" + uuid + "_resume_skip_arrow'>&nbsp;</span>" +
-      "  Skip to where you left off" +
-      "</a>" +
-      "</div>";
-      video.grid.top_inside.appendChild(resumeScreen);
-      refreshCss();
-      centerVertically();
-      var resumePlayElem = document.getElementById(uuid + "_resume_play");
-      var resumeSkipElem = document.getElementById(uuid + "_resume_skip");
+    // the resumable lab doesn't work well with autoplay.
+    // The video might already be autoplaying by the time we get here,
+    // so don't attempt to show the resumable overlay.
+    if (video.options.autoPlay === false) {
+      removeOverlay();
+      if (resumeTime()) {
+        if (video.state() === "beforeplay") {
+          video.suppressPlay(true);
+          video.pause();
+        } else {
+          video.pause();
+        }
+        var resumeScreen = document.createElement("div");
+        resumeScreen.id = uuid;
+        resumeScreen.innerHTML = "" +
+        "<div id='" + uuid + "_content'>" +
+        "<div>It looks like you've watched<br />part of this video before!</div>" +
+        "<a href='#' id='" + uuid + "_resume_play'>" +
+        "  <span id='" + uuid + "_resume_play_arrow'>&nbsp;</span>" +
+        "  Watch from the beginning" +
+        "</a><a href='#' id='" + uuid + "_resume_skip'>" +
+        "  <span id='" + uuid + "_resume_skip_arrow'>&nbsp;</span>" +
+        "  Skip to where you left off" +
+        "</a>" +
+        "</div>";
+        video.grid.top_inside.appendChild(resumeScreen);
+        refreshCss();
+        centerVertically();
+        var resumePlayElem = document.getElementById(uuid + "_resume_play");
+        var resumeSkipElem = document.getElementById(uuid + "_resume_skip");
 
-      resumeSkipElem.onclick = function() {
-        video.suppressPlay(false);
-        jumpToResumeTime();
+        resumeSkipElem.onclick = function() {
+          video.suppressPlay(false);
+          jumpToResumeTime();
+          return false;
+        };
+        resumePlayElem.onclick = function() {
+          video.suppressPlay(false);
+          playFromBeginning();
+          return false;
+        };
+        return true;
+      }
+      else {
         return false;
-      };
-      resumePlayElem.onclick = function() {
-        video.suppressPlay(false);
-        playFromBeginning();
-        return false;
-      };
-      return true;
-    }
-    else {
-      return false;
+      }
     }
   }
 


### PR DESCRIPTION
Currently, if a video has both autoplay and the resumable lab enabled, the video will autoplay from the start while the resumable overlay appears. It's a weird, bad state to be in. Issue: https://github.com/wistia/wistia/issues/4346

This PR does two things:

1. Adds a note about how resumable and autoplay don't get along.
2. Makes a small change to the plugin, to let autoplay work normally and not show the resumable overlay at all. We do this by checking `if (video.options.autoPlay === false)` before showing the overlay.

Trello card: https://trello.com/c/8Vzb4S0k/56-update-resumable-lab-page-to-note-it-doesn-t-work-with-autoplay

@jeffvincent LGTY?