### PR TITLE
Fix logic to detect if autoPlay is enabled

### DIFF
--- a/resumable/plugin.js
+++ b/resumable/plugin.js
@@ -149,7 +149,7 @@ Wistia.plugin("resumable", function(video, options) {
     // the resumable lab doesn't work well with autoplay.
     // The video might already be autoplaying by the time we get here,
     // so don't attempt to show the resumable overlay.
-    if (video.options.autoPlay === false) {
+    if (!(video.options.autoPlay == true)) {
       removeOverlay();
       if (resumeTime()) {
         if (video.state() === "beforeplay") {
@@ -199,7 +199,7 @@ Wistia.plugin("resumable", function(video, options) {
     if (!showOverlay()) {
       setTime(0);
     }
-    
+
     video.bind("secondchange", setTime)
 
     video.bind("end", function() {


### PR DESCRIPTION
Turns out I broke the resumable lab, with https://github.com/wistia/wistia-labs/pull/27. I thought that `video.options.autoPlay` would always be `true` or `false`, but sometimes it is `undefined`. So if we want to only have the resumable lab function for videos that don't have autoplay enabled, we must check that `autoPlay` is not `true`, rather than checking if it is `false`.